### PR TITLE
Error parsing MultiValue PersonName data

### DIFF
--- a/bin/record.py
+++ b/bin/record.py
@@ -22,7 +22,6 @@ import os
 import sys
 import tempfile
 import traceback
-import pdb
 
 haveImage = True
 try:
@@ -65,10 +64,6 @@ class ChronicleRecord():
         """Returns a json dictionary which is either a single
         element or a dictionary of elements representing a sequnce.
         """
-        # DELETE
-        # if dataElement.tag == pydicom.tag.BaseTag(0x00101001):
-        #     pdb.set_trace()
-        # DELETE
         if dataElement.VR in self.BINARY_VR_VALUES:
             value = "Binary Omitted"
         elif dataElement.VR == "SQ":
@@ -86,16 +81,13 @@ class ChronicleRecord():
                 value = value.encode('utf-8')
             elif isinstance(value, pydicom.valuerep.PersonName):
                 print(f"PersonName: {value}")
-                # pdb.set_trace()
                 if value.original_string:
                   value = value.original_string.decode()
                 else:
                   value = ""
-        # try:
         try:
             print(f"serializing {value}, {dataElement.VR}")
             if isinstance(value, pydicom.multival.MultiValue):
-                # pdb.set_trace()
                 value = [str(i) for i in value]
             else:
                 couchdb.json.encode(value).encode('utf-8')
@@ -106,8 +98,6 @@ class ChronicleRecord():
             "vr" : dataElement.VR,
             "Value" : value
         }
-        # except UnboundLocalError:
-        #     print ("UnboundLocalError: ", dataElement)
         return json
 
     def datasetToJSON(self,dataset):
@@ -125,7 +115,6 @@ class ChronicleRecord():
             jkey = "%04X%04X" % (key.group,key.element)
             try:
                 dataElement = dataset[key]
-                # pdb.set_trace()
                 jsonDictionary[jkey] = self.dataElementToJSON(dataElement)
             except KeyError:
                 print("KeyError: ", key)
@@ -226,7 +215,6 @@ class ChronicleRecord():
     def recordDirectory(self,directoryPath):
         """Perform the record"""
         for root, dirs, files in os.walk(directoryPath):
-            # pdb.set_trace()
             for fileName in files:
                 fileNamePath = os.path.join(root,fileName)
                 self.recordFile(fileNamePath)
@@ -258,34 +246,8 @@ class ChronicleRecord():
             'dataset': jsonDictionary
         }
 
-        print('...saving...')
-        for data_tag in document['dataset'].keys():
-            dt = data_tag
-            t = document['dataset'][data_tag]
-            if not isinstance(dt,str) or not isinstance(t,dict):
-                # pass
-                print("really though")
-                # pdb.set_trace()
-
-        # DELETE
-        # del document['dataset']['00101001']
-        # document['dataset']['00082112']
-        # document['dataset'] = document['dataset']['00082112']
-        # document['dataset']['00400007']
-        # fake_document = dict(document)
-        # for key in document['dataset'].keys():
-        #     print(key)
-        #     fake_document['dataset'] = {key: document['dataset'][key]}
-        #     # pdb.set_trace()
-        #     # if key == "00101001":
-        #     if key == "00080008":
-        #         print("###################")
-        #         pdb.set_trace()
-        #     doc_id, doc_rev = self.db.save(fake_document)
-        # DELETE
-        
+        print('...saving...')        
         doc_id, doc_rev = self.db.save(document)
-
         # save the document
         try:
             print('...saving...')

--- a/bin/record.py
+++ b/bin/record.py
@@ -22,6 +22,7 @@ import os
 import sys
 import tempfile
 import traceback
+import pdb
 
 haveImage = True
 try:
@@ -64,6 +65,10 @@ class ChronicleRecord():
         """Returns a json dictionary which is either a single
         element or a dictionary of elements representing a sequnce.
         """
+        # DELETE
+        # if dataElement.tag == pydicom.tag.BaseTag(0x00101001):
+        #     pdb.set_trace()
+        # DELETE
         if dataElement.VR in self.BINARY_VR_VALUES:
             value = "Binary Omitted"
         elif dataElement.VR == "SQ":
@@ -79,25 +84,30 @@ class ChronicleRecord():
             value = dataElement.value
             if isinstance(value, bytes):
                 value = value.encode('utf-8')
-            elif isinstance(value, pydicom.valuerep.PersonName3):
-                print(f"PersonName3: {value}")
+            elif isinstance(value, pydicom.valuerep.PersonName):
+                print(f"PersonName: {value}")
+                # pdb.set_trace()
                 if value.original_string:
                   value = value.original_string.decode()
                 else:
                   value = ""
+        # try:
         try:
-            try:
-                print(f"serializing {value}, {dataElement.VR}")
+            print(f"serializing {value}, {dataElement.VR}")
+            if isinstance(value, pydicom.multival.MultiValue):
+                # pdb.set_trace()
+                value = [str(i) for i in value]
+            else:
                 couchdb.json.encode(value).encode('utf-8')
-            except ValueError:
-                print('Skipping non-encodable value', value)
-                value = "Not encodable"
-            json = {
-                "vr" : dataElement.VR,
-                "Value" : value
-            }
-        except UnboundLocalError:
-            print ("UnboundLocalError: ", dataElement)
+        except ValueError:
+            print('Skipping non-encodable value', value)
+            value = "Not encodable"
+        json = {
+            "vr" : dataElement.VR,
+            "Value" : value
+        }
+        # except UnboundLocalError:
+        #     print ("UnboundLocalError: ", dataElement)
         return json
 
     def datasetToJSON(self,dataset):
@@ -115,6 +125,7 @@ class ChronicleRecord():
             jkey = "%04X%04X" % (key.group,key.element)
             try:
                 dataElement = dataset[key]
+                # pdb.set_trace()
                 jsonDictionary[jkey] = self.dataElementToJSON(dataElement)
             except KeyError:
                 print("KeyError: ", key)
@@ -215,13 +226,13 @@ class ChronicleRecord():
     def recordDirectory(self,directoryPath):
         """Perform the record"""
         for root, dirs, files in os.walk(directoryPath):
+            # pdb.set_trace()
             for fileName in files:
                 fileNamePath = os.path.join(root,fileName)
                 self.recordFile(fileNamePath)
 
     def recordFile(self,fileNamePath):
         print("Considering file: %s" % fileNamePath)
-
         # create dataset, skip non-dicom
         try:
             dataset = pydicom.read_file(fileNamePath)
@@ -248,6 +259,31 @@ class ChronicleRecord():
         }
 
         print('...saving...')
+        for data_tag in document['dataset'].keys():
+            dt = data_tag
+            t = document['dataset'][data_tag]
+            if not isinstance(dt,str) or not isinstance(t,dict):
+                # pass
+                print("really though")
+                # pdb.set_trace()
+
+        # DELETE
+        # del document['dataset']['00101001']
+        # document['dataset']['00082112']
+        # document['dataset'] = document['dataset']['00082112']
+        # document['dataset']['00400007']
+        # fake_document = dict(document)
+        # for key in document['dataset'].keys():
+        #     print(key)
+        #     fake_document['dataset'] = {key: document['dataset'][key]}
+        #     # pdb.set_trace()
+        #     # if key == "00101001":
+        #     if key == "00080008":
+        #         print("###################")
+        #         pdb.set_trace()
+        #     doc_id, doc_rev = self.db.save(fake_document)
+        # DELETE
+        
         doc_id, doc_rev = self.db.save(document)
 
         # save the document

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pydicom==2.2.0
+CouchDB==1.2
+Pillow==8.3.1
+numpy==1.21.2


### PR DESCRIPTION
DICOM tag [(0010,1001)](http://dicomlookup.com/lookup.asp?sw=Tnumber&q=(0010,1001)) can sometime yield a list of PersonName objects inside a MultiValue object. In the past the code to deal with this was as follows:

~ line 90 in record.py
```
...
            if isinstance(value, pydicom.multival.MultiValue):
                value = [i for i in value]
...
```
The problem is that normally for most PersonName records, the MultiValue object yield str objects once in a list comprehension as is the case for "value" above. However for tag (0010,1001), the MultiValue instances, denoted as "i" above, are PersonName objects instead of str objects. This causes an error in the stadard json library later as it does not recognize PersonName objects. 

Proposed main change:
```
...
            if isinstance(value, pydicom.multival.MultiValue):
                value = [str(i) for i in value]
...
```
Once cast to str, loading of DICOM data works flawlessly. 

PS: There are a handful of other changes dealing mostly with error handling syntax differences between python2 and python3. Lastly, any references to ["PersonName3"](https://github.com/pydicom/pydicom/blob/v1.4.2/pydicom/valuerep.py) on line ~631, have been removed as that class no longer exists (https://github.com/pydicom/pydicom/blob/master/pydicom/valuerep.py).


Lastly: I added a requirements.txt to lock in the new versions of things I am using. No need to absolutely use those.