### PR TITLE
Optional Pull Request

### DIFF
--- a/bin/record.py
+++ b/bin/record.py
@@ -79,9 +79,9 @@ class ChronicleRecord():
             value = dataElement.value
             if isinstance(value, bytes):
                 try:
-                    value = value.encode('utf-8')
+                    value = value.decode('utf-8')
                 except AttributeError:
-                    value = str(value) # Private tags have non-standard 
+                    value = str(value) # Private tags have non-standard encoding and we don't know what it is necessarily
             elif isinstance(value, pydicom.valuerep.PersonName):
                 print(f"PersonName: {value}")
                 if value.original_string:

--- a/bin/record.py
+++ b/bin/record.py
@@ -269,16 +269,16 @@ class ChronicleRecord():
         if self.attachImages:
             doc = self.db.get(doc_id)
             images = self.imagesFromDataset(dataset)
-          for imageSize in [512]: #images.keys():
-              print('...thumbnail %d...' % imageSize)
-              imageName = "image%d.png" % imageSize
-              imageFD, imagePath = tempfile.mkstemp(suffix='.png')
-              os.fdopen(imageFD,'w').close()
-              images[imageSize].save(imagePath)
-              fp = open(imagePath, "rb")
-              self.db.put_attachment(doc, fp, imageName, content_type='image/png')
-              fp.close()
-              os.remove(imagePath)
+            for imageSize in images.keys():
+                print('...thumbnail %d...' % imageSize)
+                imageName = "image%d.png" % imageSize
+                imageFD, imagePath = tempfile.mkstemp(suffix='.png')
+                os.fdopen(imageFD,'w').close()
+                images[imageSize].save(imagePath)
+                fp = open(imagePath, "rb")
+                self.db.put_attachment(doc, fp, imageName, content_type='image/png')
+                fp.close()
+                os.remove(imagePath)
 
         # attach the original file
         if self.attachOriginals:

--- a/bin/record.py
+++ b/bin/record.py
@@ -78,7 +78,10 @@ class ChronicleRecord():
         else:
             value = dataElement.value
             if isinstance(value, bytes):
-                value = value.encode('utf-8')
+                try:
+                    value = value.encode('utf-8')
+                except AttributeError:
+                    value = str(value) # Private tags have non-standard 
             elif isinstance(value, pydicom.valuerep.PersonName):
                 print(f"PersonName: {value}")
                 if value.original_string:
@@ -145,7 +148,7 @@ class ChronicleRecord():
             # DICOM dataset does not have pixel data
             print('no pixels')
             return None
-        if ('SamplesperPixel' not in dataset):
+        if ('SamplesPerPixel' not in dataset):
             print('no samples')
             return None
         if ('WindowWidth' not in dataset) or ('WindowCenter' not in dataset):
@@ -264,18 +267,18 @@ class ChronicleRecord():
 
         # attach png images to the object if possible
         if self.attachImages:
-          doc = self.db.get(doc_id)
-          images = self.imagesFromDataset(dataset)
-          for imageSize in images.keys():
-            print('...thumbnail %d...' % imageSize)
-            imageName = "image%d.png" % imageSize
-            imageFD, imagePath = tempfile.mkstemp(suffix='.png')
-            os.fdopen(imageFD,'w').close()
-            images[imageSize].save(imagePath)
-            fp = open(imagePath)
-            self.db.put_attachment(doc, fp, imageName)
-            fp.close()
-            os.remove(imagePath)
+            doc = self.db.get(doc_id)
+            images = self.imagesFromDataset(dataset)
+          for imageSize in [512]: #images.keys():
+              print('...thumbnail %d...' % imageSize)
+              imageName = "image%d.png" % imageSize
+              imageFD, imagePath = tempfile.mkstemp(suffix='.png')
+              os.fdopen(imageFD,'w').close()
+              images[imageSize].save(imagePath)
+              fp = open(imagePath, "rb")
+              self.db.put_attachment(doc, fp, imageName, content_type='image/png')
+              fp.close()
+              os.remove(imagePath)
 
         # attach the original file
         if self.attachOriginals:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pydicom==2.2.0
-CouchDB==1.2
-Pillow==8.3.1
-numpy==1.21.2
+pydicom
+CouchDB
+Pillow
+numpy


### PR DESCRIPTION
Summary of Changes Suggested:

* Lines 81-84: Some DICOMs have private tags that are not standard and it's hard to predict what information is in them and therefore parsing can fail. In python3, bytes objects don't have an encode method anymore so this section should be re-written to have a better interface with bytes objects and encoding in general. That being said, if 'utf-8' decoding of the bytes fails we will just store the literal byte string stored as an actual string.
* Line 151: "SamplesperPixel" needs to be "SamplesPerPixel" as the former doesn't exist in pydicom. This was causing failures. I know in some places the word "per" is lowercase, however I found that for pydicom now, we need it to be uppercase.
* Lines 270-281 have a 2 space indention and I made it 4 as per normal python syntax. Also fp = open(imagePath, "rb") didn't have 'rb' and was causing a read error. Reading the binary is helping read the image data. Adding content_type='image/png' to self.db.put_attachment(), isn't necessary as that method will make some assumptions or try to figure out the content_type, but we know we are making pngs, so I figure being explicit is reasonable.
* Requirements were changed to be dynamic. Probably not the best idea but if we lock in the versions they will eventually get stale. I defer to the original author for best practices here.